### PR TITLE
Add option to hide armorstand's healthbar

### DIFF
--- a/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
+++ b/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
@@ -41,6 +41,10 @@ public class HealthBarRenderer {
     if (Mode.WHEN_HOLDING_WEAPON.equals(getConfig().mode) && !ToroHealth.IS_HOLDING_WEAPON) {
       return;
     }
+
+    if(getConfig().hideArmorStands && entity instanceof ArmorStandEntity) {
+      return;
+    }
     MinecraftClient client = MinecraftClient.getInstance();
 
     float scaleToGui = 0.025f;

--- a/src/main/java/net/torocraft/torohealth/config/Config.java
+++ b/src/main/java/net/torocraft/torohealth/config/Config.java
@@ -31,6 +31,7 @@ public class Config implements IConfig {
     public boolean showEntity = true;
     public boolean showBar = true;
     public boolean showSkin = true;
+    public boolean hideArmorStands = false;
   }
 
   public static class Particle {
@@ -49,6 +50,7 @@ public class Config implements IConfig {
 
   public static class InWorld {
     public Mode mode = Mode.NONE;
+    public boolean hideArmorStands = true;
     public float distance = 60f;
   }
 

--- a/src/main/java/net/torocraft/torohealth/display/Hud.java
+++ b/src/main/java/net/torocraft/torohealth/display/Hud.java
@@ -67,16 +67,21 @@ public class Hud extends Screen {
   }
 
   public void setEntity(LivingEntity entity) {
+    if(ToroHealth.CONFIG.hud.hideArmorStands && entity instanceof ArmorStandEntity) {
+      if(age > ToroHealth.CONFIG.hud.hideDelay)
+        setEntityWork(null);
+      return;
+    }
+
     if (entity != null) {
       age = 0;
+      if (entity != this.entity) {
+        setEntityWork(entity);
+      }
     }
 
     if (entity == null && age > ToroHealth.CONFIG.hud.hideDelay) {
       setEntityWork(null);
-    }
-
-    if (entity != null && entity != this.entity) {
-      setEntityWork(entity);
     }
   }
 


### PR DESCRIPTION
This patch allows to hide armorstand's healthbars.
Because why do you even want to hurt these little creatures that hold your armor?