### PR TITLE
Fixed healthbars render while you are blind

### DIFF
--- a/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
+++ b/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
@@ -82,6 +82,7 @@ public class HealthBarRenderer {
 
     RenderSystem.disableLighting();
     RenderSystem.enableDepthTest();
+    RenderSystem.enableFog();
     RenderSystem.disableAlphaTest();
     RenderSystem.enableBlend();
     RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE,


### PR DESCRIPTION
Healthbars are no longer displayed if you cannot see them, therefore not giving players an unfair advantage.