### PR TITLE
Fixed lighting bug with Optifine in 1.16.5

### DIFF
--- a/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
+++ b/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
@@ -102,6 +102,7 @@ public class HealthBarRenderer {
     RenderSystem.shadeModel(7424);
     RenderSystem.disableBlend();
     RenderSystem.enableAlphaTest();
+    RenderSystem.enableLighting();
 
     matrix.pop();
   }

--- a/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
+++ b/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
@@ -35,7 +35,7 @@ public class HealthBarRenderer {
     return ToroHealth.CONFIG.inWorld;
   }
 
-  private static List<LivingEntity> renderedEntities = new ArrayList<>();
+  private static final List<LivingEntity> renderedEntities = new ArrayList<>();
 
   public static void prepareRenderInWorld(LivingEntity entity) {
 
@@ -82,6 +82,19 @@ public class HealthBarRenderer {
       return;
     }
 
+    if (renderedEntities.isEmpty()) {
+      return;
+    }
+
+    RenderSystem.disableLighting();
+    RenderSystem.enableDepthTest();
+    RenderSystem.enableFog();
+    RenderSystem.disableAlphaTest();
+    RenderSystem.enableBlend();
+    RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE,
+            GL11.GL_ZERO);
+    RenderSystem.shadeModel(7425);
+
     for (LivingEntity entity : renderedEntities) {
       float scaleToGui = 0.025f;
       boolean sneaking = entity.isInSneakingPose();
@@ -103,24 +116,15 @@ public class HealthBarRenderer {
       matrix.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(camera.getPitch()));
       matrix.scale(-scaleToGui, -scaleToGui, scaleToGui);
 
-      RenderSystem.disableLighting();
-      RenderSystem.enableDepthTest();
-      RenderSystem.enableFog();
-      RenderSystem.disableAlphaTest();
-      RenderSystem.enableBlend();
-      RenderSystem.blendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE,
-              GL11.GL_ZERO);
-      RenderSystem.shadeModel(7425);
-
       render(matrix, entity, 0, 0, FULL_SIZE, true);
-
-      RenderSystem.shadeModel(7424);
-      RenderSystem.disableBlend();
-      RenderSystem.enableAlphaTest();
-      RenderSystem.enableLighting();
 
       matrix.pop();
     }
+
+    RenderSystem.shadeModel(7424);
+    RenderSystem.disableBlend();
+    RenderSystem.enableAlphaTest();
+    RenderSystem.enableLighting();
 
     renderedEntities.clear();
   }

--- a/src/main/java/net/torocraft/torohealth/bars/ParticleRenderer.java
+++ b/src/main/java/net/torocraft/torohealth/bars/ParticleRenderer.java
@@ -51,6 +51,7 @@ public class ParticleRenderer {
     RenderSystem.shadeModel(7424);
     RenderSystem.disableBlend();
     RenderSystem.enableAlphaTest();
+    RenderSystem.enableLighting();
 
     matrix.pop();
   }

--- a/src/main/java/net/torocraft/torohealth/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/torocraft/torohealth/mixin/WorldRendererMixin.java
@@ -28,7 +28,7 @@ public class WorldRendererMixin {
   private void renderEntity(Entity entity, double x, double y, double z, float g,
       MatrixStack matrix, VertexConsumerProvider v, CallbackInfo info) {
     if (entity instanceof LivingEntity) {
-      HealthBarRenderer.renderInWorld(matrix, (LivingEntity) entity, entityRenderDispatcher.camera);
+      HealthBarRenderer.prepareRenderInWorld((LivingEntity) entity);
     }
   }
 
@@ -36,6 +36,7 @@ public class WorldRendererMixin {
   private void render(MatrixStack matrices, float tickDelta, long limitTime,
       boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer,
       LightmapTextureManager lightmapTextureManager, Matrix4f matrix, CallbackInfo info) {
+    HealthBarRenderer.renderInWorld(matrices, camera);
     ParticleRenderer.renderParticles(matrices, camera);
   }
 


### PR DESCRIPTION
This PR fixes lighting not being re-enabled after rendering health bars, which causes some entities to be rendered without lighting.

This issue is probably only present with Optifine installed. See also the third comment in #60.

BTW, since you do not have a branch for 1.16.5 this PR targets 1.16.3.