### PR TITLE
Hide health bars for armor stands and invisible entities that aren't glowing

### DIFF
--- a/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
+++ b/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
@@ -44,7 +44,7 @@ public class HealthBarRenderer {
 
     MinecraftClient client = MinecraftClient.getInstance();
 
-    if (client.player == entity) {
+    if (!EntityUtil.showHealthBar(entity, client)) {
       return;
     }
 

--- a/src/main/java/net/torocraft/torohealth/util/EntityUtil.java
+++ b/src/main/java/net/torocraft/torohealth/util/EntityUtil.java
@@ -5,6 +5,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.entity.mob.AmbientEntity;
+import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.mob.GhastEntity;
 import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.mob.SlimeEntity;
@@ -49,6 +50,7 @@ public class EntityUtil {
             && (!entity.isInvisibleTo(client.player)
                 || entity.isGlowing()
                 || entity.isOnFire()
+                || entity instanceof CreeperEntity && ((CreeperEntity) entity).shouldRenderOverlay() // charged creeper
                 || StreamSupport.stream(entity.getItemsEquipped().spliterator(), false).anyMatch(is -> !is.isEmpty()))
             && entity != client.player
             && !entity.isSpectator();

--- a/src/main/java/net/torocraft/torohealth/util/EntityUtil.java
+++ b/src/main/java/net/torocraft/torohealth/util/EntityUtil.java
@@ -13,6 +13,8 @@ import net.minecraft.entity.passive.FishEntity;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.passive.SquidEntity;
 
+import java.util.stream.StreamSupport;
+
 public class EntityUtil {
 
   public enum Relation {
@@ -44,7 +46,10 @@ public class EntityUtil {
   public static boolean showHealthBar(Entity entity, MinecraftClient client) {
     return entity instanceof LivingEntity
             && !(entity instanceof ArmorStandEntity)
-            && (!entity.isInvisibleTo(client.player) || entity.isGlowing())
+            && (!entity.isInvisibleTo(client.player)
+                || entity.isGlowing()
+                || entity.isOnFire()
+                || StreamSupport.stream(entity.getItemsEquipped().spliterator(), false).anyMatch(is -> !is.isEmpty()))
             && entity != client.player
             && !entity.isSpectator();
   }

--- a/src/main/java/net/torocraft/torohealth/util/EntityUtil.java
+++ b/src/main/java/net/torocraft/torohealth/util/EntityUtil.java
@@ -1,6 +1,9 @@
 package net.torocraft.torohealth.util;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.entity.mob.AmbientEntity;
 import net.minecraft.entity.mob.GhastEntity;
 import net.minecraft.entity.mob.HostileEntity;
@@ -36,5 +39,13 @@ public class EntityUtil {
     } else {
       return Relation.UNKNOWN;
     }
+  }
+
+  public static boolean showHealthBar(Entity entity, MinecraftClient client) {
+    return entity instanceof LivingEntity
+            && !(entity instanceof ArmorStandEntity)
+            && (!entity.isInvisibleTo(client.player) || entity.isGlowing())
+            && entity != client.player
+            && !entity.isSpectator();
   }
 }

--- a/src/main/java/net/torocraft/torohealth/util/RayTrace.java
+++ b/src/main/java/net/torocraft/torohealth/util/RayTrace.java
@@ -1,6 +1,5 @@
 package net.torocraft.torohealth.util;
 
-import java.util.function.Predicate;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
@@ -23,8 +22,9 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.RaycastContext;
 import net.minecraft.world.RaycastContext.FluidHandling;
 
+import java.util.function.Predicate;
+
 public class RayTrace implements BlockView {
-  private static Predicate<Entity> isVisible = entity -> !entity.isSpectator() && entity.collides();
   private static MinecraftClient minecraft = MinecraftClient.getInstance();
 
   @Override
@@ -55,6 +55,7 @@ public class RayTrace implements BlockView {
     Vec3d max = position.add(look.x * reachDistance, look.y * reachDistance, look.z * reachDistance);
     Box searchBox = viewer.getBoundingBox().stretch(look.multiply(reachDistance)).expand(1.0D, 1.0D, 1.0D);
 
+    Predicate<Entity> isVisible = entity -> entity.collides() && EntityUtil.showHealthBar(entity, client);
     EntityHitResult result = ProjectileUtil.raycast(viewer, position, max, searchBox, isVisible, reachDistance * reachDistance);
 
     if (result == null || result.getEntity() == null) {


### PR DESCRIPTION
Armor stands should not have health bars, see PR #61.

Invisible entities also should not have health bars, see issue #86. The health bar of invisible entities is shown if they are glowing though, as the glowing effect makes them (partially) visible again.

Since there is no branch for 1.16.5 this PR targets 1.16.3.