### PR TITLE
Changed the text health display to use the proper current health of an entity instead of capping it at max health.

### DIFF
--- a/src/main/java/net/torocraft/torohealth/bars/BarState.java
+++ b/src/main/java/net/torocraft/torohealth/bars/BarState.java
@@ -25,7 +25,7 @@ public class BarState {
   }
 
   public void tick() {
-    health = Math.min(entity.getHealth(), entity.getMaxHealth());
+    health = entity.getHealth();
     incrementTimers();
 
     if (lastHealth < 0.1) {

--- a/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
+++ b/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
@@ -118,8 +118,8 @@ public class HealthBarRenderer {
 
     BarState state = BarStates.getState(entity);
 
-    float percent = Math.min(1, state.health / entity.getMaxHealth());
-    float percent2 = state.previousHealthDisplay / entity.getMaxHealth();
+    float percent = Math.min(1, Math.min(state.health, entity.getMaxHealth()) / entity.getMaxHealth());
+    float percent2 = Math.min(state.previousHealthDisplay, entity.getMaxHealth()) / entity.getMaxHealth();
     int zOffset = 0;
 
     Matrix4f m4f = matrix.peek().getModel();

--- a/src/main/java/net/torocraft/torohealth/display/BarDisplay.java
+++ b/src/main/java/net/torocraft/torohealth/display/BarDisplay.java
@@ -31,7 +31,7 @@ public class BarDisplay {
     HealthBarRenderer.render(matrix, entity, 63, 14, 130, false);
     String name = getEntityName(entity);
     int healthMax = MathHelper.ceil(entity.getMaxHealth());
-    int healthCur = Math.min(MathHelper.ceil(entity.getHealth()), healthMax);
+    int healthCur = MathHelper.ceil(entity.getHealth());
     String healthText = healthCur + "/" + healthMax;
     GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
 
@@ -52,7 +52,7 @@ public class BarDisplay {
     if (armor > 0) {
       renderArmorIcon(matrix, xOffset, (int) 1);
       xOffset += 10;
-      mc.textRenderer.drawWithShadow(matrix, entity.getArmor() + "", xOffset, 2, 0xe0e0e0);
+      mc.textRenderer.drawWithShadow(matrix, armor + "", xOffset, 2, 0xe0e0e0);
     }
   }
 


### PR DESCRIPTION
Health bars are unaffected by this change - they still show full health as long as the current health is >= max health.

Since there is no branch for 1.16.5 this PR targets 1.16.3.