### PR TITLE
Fix color parsing using java.awt.Color

### DIFF
--- a/src/main/java/net/torocraft/torohealth/config/loader/ColorJsonAdpater.java
+++ b/src/main/java/net/torocraft/torohealth/config/loader/ColorJsonAdpater.java
@@ -1,31 +1,29 @@
 package net.torocraft.torohealth.config.loader;
 
+import com.google.common.base.CharMatcher;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import java.awt.Color;
 import java.io.IOException;
 
 public class ColorJsonAdpater extends TypeAdapter<Integer> {
 
+  private static final CharMatcher HEX = CharMatcher.anyOf("0123456789abcdefABCDEF");
+
   @Override
   public void write(JsonWriter out, Integer value) throws IOException {
-    String hex = Integer.toHexString(value & 0xffffff);
-    hex = String.format("#%1$6s", hex).replace(' ', '0');
+    String hex = String.format("#%06x", value & 0xFFFFFF);
     out.value(hex);
   }
 
   @Override
   public Integer read(JsonReader in) throws IOException {
     String read = in.nextString();
-    try {
-      Color c = Color.decode(read);
-      return c.getRGB();
-    } catch (Exception e) {
+    if (read.charAt(0) != '#' || read.length() != 7 || !HEX.matchesAllOf(read.substring(1))) {
       System.out.println("ToroHealth: failed to parse color [" + read + "]");
-      e.printStackTrace();
       return null;
     }
+    return Integer.parseInt(read.substring(1), 16);
   }
 
 }


### PR DESCRIPTION
For reasons known to no-one, using java.awt.Color initializes the AWT Toolkit.

This is illegal in LWJGL3-based versions of Minecraft, and causes strange and hard to debug issues, especially on macOS. These issues generally are hard to see or do not occur on Linux and Windows, unless using other mods that do native tricks like MumbleLink.

This PR removes the usage of java.awt.Color from ColorJsonAdpater (sic) and replaces it with manual parsing. Also changed the writer method to use a proper string format specifier instead of replacing spaces after a string interp.

ColorJsonAdpater should probably get renamed to ColorJson*Adapter*, but that's out of the scope of this PR.