### PR TITLE
Remove deprecated client-side-only ModMenu marker

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,9 +26,6 @@
   "suggests": {
     "modmenu": "*"
   },
-  "custom": {
-    "modmenu:clientsideOnly": true
-  },
   "depends": {
     "fabricloader": ">=0.7.4",
     "fabric": "*",


### PR DESCRIPTION
This causes a log message: `[11:59:03] [Render thread/WARN]: WARNING! Mod torohealth is only using deprecated 'modmenu:clientsideOnly' custom value! This is no longer needed and will be removed in 1.18 snapshots.`