### PR TITLE
Port to Minecraft 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.12-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -10,8 +10,6 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
-minecraft {
-}
 
 dependencies {
     //to change the versions see the gradle.properties file

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,14 +8,14 @@ org.gradle.jvmargs=-Xmx1G
 # To remap the mixin locations:
 # gradlew migrateMappings --mappings "1.16.1+build.9"
 
-minecraft_version=1.18
-yarn_mappings=1.18+build.1
-loader_version=0.12.8
+minecraft_version=1.19
+yarn_mappings=1.19+build.1
+loader_version=0.14.6
 
 #Fabric api
-fabric_version=0.44.0+1.18
+fabric_version=0.55.2+1.19
 
 # Mod Properties
-mod_version = 1.18-fabric-2
+mod_version = 1.19-fabric-1
 maven_group = net.torocraft
 archives_base_name = torohealth

--- a/src/main/java/net/torocraft/torohealth/display/Hud.java
+++ b/src/main/java/net/torocraft/torohealth/display/Hud.java
@@ -5,7 +5,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.*;
 import net.minecraft.util.Identifier;
 import net.torocraft.torohealth.ToroHealth;
 import net.torocraft.torohealth.config.Config;
@@ -21,7 +21,7 @@ public class Hud extends Screen {
   private int age;
 
   public Hud() {
-    super(new LiteralText("ToroHealth HUD"));
+    super(Text.literal("ToroHealth HUD"));
     this.client = MinecraftClient.getInstance();
     barDisplay = new BarDisplay(MinecraftClient.getInstance(), this);
   }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,9 +27,9 @@
     "modmenu": "*"
   },
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.14.6",
     "fabric": "*",
-    "minecraft": "1.18.x",
+    "minecraft": "1.19.x",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
- Upgrade to Minecraft 1.19
- Upgrade to Fabric Loom 0.12
- Upgrade to Fabric Loader 0.14.6
- Upgrade to Yarn Mappings 1.19+build.1
- Upgrade to Fabric API 0.55.2+1.19
- Swap "new LiteralText()" for "Text.literal()" as is required by the new 1.19 API
- Remove deprecated minecraft function from build.gradle

**If you have any suggestions for improvement, please let me know!**