### PR TITLE
Update mods.toml to not cause red X when client-side only

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -14,6 +14,7 @@ authors="ToroCraft"
 description='''
   Health bars will appear in the top left corner for the entity in the player's crosshairs.
   '''
+displayTest="IGNORE_ALL_VERSION"
 
 [[dependencies.torohealth]]
 modId="forge"


### PR DESCRIPTION
### Issue
Toro Health causes the sidedness checker in Forge to throw a red X if the mod is only installed client-side, which of course is a problem when the mod isn't needed on the server (nor works if on the server).

### Solution
This may be a bit of a bandaid, but the solution here is to use Forge's `displayTest` parameter within mods.toml to ignore any X flagging. This is documented here: https://docs.minecraftforge.net/en/latest/concepts/sides/#writing-one-sided-mods