### PR TITLE
 Fixed entity reloading error, issues/82

### DIFF
--- a/src/main/java/net/torocraft/torohealth/bars/BarState.java
+++ b/src/main/java/net/torocraft/torohealth/bars/BarState.java
@@ -1,85 +1,106 @@
 package net.torocraft.torohealth.bars;
 
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.client.MinecraftClient;
 import net.torocraft.torohealth.ToroHealth;
 
 public class BarState {
 
-  public final LivingEntity entity;
+    public final Integer entityID;
 
-  public float health;
-  public float previousHealth;
-  public float previousHealthDisplay;
-  public float previousHealthDelay;
-  public int lastDmg;
-  public int lastDmgCumulative;
-  public float lastHealth;
-  public float lastDmgDelay;
-  private float animationSpeed = 0;
+    public float health;
+    public float previousHealthDisplay;
+    public float previousHealthDelay;
+    public int lastDmg;
+    public int lastDmgCumulative;
+    public float lastHealth;
+    public float lastDmgDelay;
+    private float animationSpeed;
 
-  private static final float HEALTH_INDICATOR_DELAY = 10;
+    private static final float HEALTH_INDICATOR_DELAY = 10;
 
-  public BarState(LivingEntity entity) {
-    this.entity = entity;
-  }
 
-  public void tick() {
-    health = Math.min(entity.getHealth(), entity.getMaxHealth());
-    incrementTimers();
 
-    if (lastHealth < 0.1) {
-      reset();
-
-    } else if (lastHealth != health) {
-      handleHealthChange();
-
-    } else if (lastDmgDelay == 0.0F) {
-      reset();
+    public BarState(Integer id) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        Entity entity = client.world != null ? client.world.getEntityById(id) : null;
+        if (entity instanceof LivingEntity living) {
+            this.entityID = id;
+            health = Math.min(living.getHealth(), living.getMaxHealth());
+            previousHealthDisplay = health;
+            lastDmg = 0;
+            lastDmgCumulative = 0;
+            lastHealth = health;
+            lastDmgDelay = 0;
+            animationSpeed = 0;
+        } else {
+            this.entityID = null; // will be ignored
+        }
     }
 
-    updateAnimations();
-  }
+    public void tick() {
+        MinecraftClient client = MinecraftClient.getInstance();
+        LivingEntity entity = (LivingEntity) client.world.getEntityById(entityID);
 
-  private void reset() {
-    lastHealth = health;
-    lastDmg = 0;
-    lastDmgCumulative = 0;
-  }
+        if (entity != null){
+            health = Math.min(entity.getHealth(), entity.getMaxHealth());
+            incrementTimers();
 
-  private void incrementTimers() {
-    if (this.lastDmgDelay > 0) {
-      this.lastDmgDelay--;
+            if (lastHealth < 0.1) {
+                reset();
+
+            } else if (lastHealth != health) {
+                handleHealthChange();
+
+            } else if (lastDmgDelay == 0.0F) {
+                reset();
+            }
+
+            updateAnimations();
+        }
     }
-    if (this.previousHealthDelay > 0) {
-      this.previousHealthDelay--;
+
+    private void reset() {
+        lastHealth = health;
+        lastDmg = 0;
+        lastDmgCumulative = 0;
     }
-  }
 
-  private void handleHealthChange() {
-    lastDmg = MathHelper.ceil(lastHealth) - MathHelper.ceil(health);
-    lastDmgCumulative += lastDmg;
-
-    lastDmgDelay = HEALTH_INDICATOR_DELAY * 2;
-    lastHealth = health;
-    if (ToroHealth.CONFIG.particle.show) {
-      BarStates.PARTICLES.add(new BarParticle(entity, lastDmg));
+    private void incrementTimers() {
+        if (this.lastDmgDelay > 0) {
+            this.lastDmgDelay--;
+        }
+        if (this.previousHealthDelay > 0) {
+            this.previousHealthDelay--;
+        }
     }
-  }
 
-  private void updateAnimations() {
-    if (previousHealthDelay > 0) {
-      float diff = previousHealthDisplay - health;
-      if (diff > 0) {
-        animationSpeed = diff / 10f;
-      }
-    } else if (previousHealthDelay < 1 && previousHealthDisplay > health) {
-      previousHealthDisplay -= animationSpeed;
-    } else {
-      previousHealthDisplay = health;
-      previousHealth = health;
-      previousHealthDelay = HEALTH_INDICATOR_DELAY;
+    private void handleHealthChange() {
+        lastDmg = MathHelper.ceil(lastHealth) - MathHelper.ceil(health);
+        lastDmgCumulative += lastDmg;
+
+        lastDmgDelay = HEALTH_INDICATOR_DELAY * 2;
+        lastHealth = health;
+        if (ToroHealth.CONFIG.particle.show) {
+            MinecraftClient client = MinecraftClient.getInstance();
+            LivingEntity entity = (LivingEntity) client.world.getEntityById(entityID);
+            BarStates.PARTICLES.add(new BarParticle(entity, lastDmg));
+        }
     }
-  }
 
+    private void updateAnimations() {
+        if (previousHealthDelay > 0) {
+            float diff = previousHealthDisplay - health;
+            if (diff > 0) {
+                animationSpeed = diff / 10f;
+            }
+        } else if (previousHealthDelay < 1 && previousHealthDisplay > health) {
+            previousHealthDisplay -= animationSpeed;
+        } else {
+            previousHealthDisplay = health;
+            previousHealthDelay = HEALTH_INDICATOR_DELAY;
+        }
+    }
 }

--- a/src/main/java/net/torocraft/torohealth/bars/BarState.java
+++ b/src/main/java/net/torocraft/torohealth/bars/BarState.java
@@ -22,26 +22,32 @@ public class BarState {
     private static final float HEALTH_INDICATOR_DELAY = 10;
 
 
-
-    public BarState(Integer id) {
-        MinecraftClient client = MinecraftClient.getInstance();
-        Entity entity = client.world != null ? client.world.getEntityById(id) : null;
-        if (entity instanceof LivingEntity living) {
-            this.entityID = id;
-            health = Math.min(living.getHealth(), living.getMaxHealth());
-            previousHealthDisplay = health;
-            lastDmg = 0;
-            lastDmgCumulative = 0;
-            lastHealth = health;
-            lastDmgDelay = 0;
-            animationSpeed = 0;
-        } else {
-            this.entityID = null; // will be ignored
-        }
+    private BarState(Integer id, float health){
+        this.entityID = id;
+        this.health = health;
+        this.previousHealthDisplay = health;
+        this.lastDmg = 0;
+        this.lastDmgCumulative = 0;
+        this.lastHealth = health;
+        this.lastDmgDelay = 0;
+        this.animationSpeed = 0;
     }
+
+    public static BarState create(Integer id){
+        MinecraftClient client = MinecraftClient.getInstance();
+        assert client.world != null;
+        Entity entity = client.world.getEntityById(id);
+        if (entity instanceof LivingEntity living) {
+            float currentHealth = Math.min(living.getHealth(), living.getMaxHealth());
+            return new BarState(id, currentHealth);
+        }
+        return  null;
+    }
+
 
     public void tick() {
         MinecraftClient client = MinecraftClient.getInstance();
+        assert client.world != null;
         LivingEntity entity = (LivingEntity) client.world.getEntityById(entityID);
 
         if (entity != null){
@@ -85,8 +91,11 @@ public class BarState {
         lastHealth = health;
         if (ToroHealth.CONFIG.particle.show) {
             MinecraftClient client = MinecraftClient.getInstance();
+            assert client.world != null;
             LivingEntity entity = (LivingEntity) client.world.getEntityById(entityID);
-            BarStates.PARTICLES.add(new BarParticle(entity, lastDmg));
+            if (entity != null) {
+                BarStates.PARTICLES.add(new BarParticle(entity, lastDmg));
+            }
         }
     }
 

--- a/src/main/java/net/torocraft/torohealth/bars/BarStates.java
+++ b/src/main/java/net/torocraft/torohealth/bars/BarStates.java
@@ -19,7 +19,9 @@ public class BarStates {
     BarState state = STATES.get(id);
     if (state == null) {
       state = BarState.create(id);
-      STATES.put(id, state);
+      if (state != null) {
+          STATES.put(id, state);
+      }
     }
     return state;
   }

--- a/src/main/java/net/torocraft/torohealth/bars/BarStates.java
+++ b/src/main/java/net/torocraft/torohealth/bars/BarStates.java
@@ -18,7 +18,7 @@ public class BarStates {
     int id = entity.getId();
     BarState state = STATES.get(id);
     if (state == null) {
-      state = new BarState(entity);
+      state = new BarState(id);
       STATES.put(id, state);
     }
     return state;

--- a/src/main/java/net/torocraft/torohealth/bars/BarStates.java
+++ b/src/main/java/net/torocraft/torohealth/bars/BarStates.java
@@ -18,7 +18,7 @@ public class BarStates {
     int id = entity.getId();
     BarState state = STATES.get(id);
     if (state == null) {
-      state = new BarState(id);
+      state = BarState.create(id);
       STATES.put(id, state);
     }
     return state;
@@ -49,6 +49,7 @@ public class BarStates {
     }
 
     MinecraftClient minecraft = MinecraftClient.getInstance();
+    assert minecraft.world != null;
     Entity entity = minecraft.world.getEntityById(entry.getKey());
 
     if (!(entity instanceof LivingEntity)) {

--- a/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
+++ b/src/main/java/net/torocraft/torohealth/bars/HealthBarRenderer.java
@@ -135,6 +135,9 @@ public class HealthBarRenderer {
         : ToroHealth.CONFIG.bar.foeColorSecondary;
 
     BarState state = BarStates.getState(entity);
+    if (state == null) {
+        return;
+    }
 
     float percent = Math.min(1, Math.min(state.health, entity.getMaxHealth()) / entity.getMaxHealth());
     float percent2 = Math.min(state.previousHealthDisplay, entity.getMaxHealth()) / entity.getMaxHealth();


### PR DESCRIPTION
The original barState stores the entity reference, which will change whenever the same entity reloads(chunk unloading/ rejoin a server, etc). This will keep this entity's barState away from updates, causing rendering errors relating to it (Issue 82 for example)
I changed the it to store entity's id rather than entity reference, which is consistent across time, so bug fixed