### PR TITLE
Bug Fix: positioning of Hud rendering doesnt match the skin position 

### DIFF
--- a/src/main/java/net/torocraft/torohealth/display/Hud.java
+++ b/src/main/java/net/torocraft/torohealth/display/Hud.java
@@ -109,11 +109,11 @@ public class Hud extends Screen {
 
     matrix.push();
     matrix.scale(scale, scale, scale);
-    matrix.translate(x - 10, y - 10, 0);
+    matrix.translate(x - 9, y - 9, 0);
     if (config.hud.showSkin) {
       this.drawSkin(matrix);
     }
-    matrix.translate(10, 10, 0);
+    matrix.translate(9, 9, 0);
     if (config.hud.showEntity) {
       entityDisplay.draw(matrix, scale);
     }


### PR DESCRIPTION
The cause of the issue is that the matrix4f used for rendering translated by 10 rather than 9, while 9 is the actual offset of the skin texture in the texture picture.
#202 