### PR TITLE
[refine]:removed some useless renderSystem settings

### DIFF
--- a/src/main/java/net/torocraft/torohealth/display/BarDisplay.java
+++ b/src/main/java/net/torocraft/torohealth/display/BarDisplay.java
@@ -28,11 +28,6 @@ public class BarDisplay {
   public void draw(MatrixStack matrix, LivingEntity entity) {
     int xOffset = 0;
 
-    RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-    RenderSystem.setShader(GameRenderer::getPositionTexShader);
-    RenderSystem.setShaderTexture(0, ICON_TEXTURES);
-    RenderSystem.enableBlend();
-
     HealthBarRenderer.render(matrix, entity, 63, 14, 130, false);
     String name = getEntityName(entity);
     int healthMax = MathHelper.ceil(entity.getMaxHealth());


### PR DESCRIPTION
This code block set the render texture to minecraft icons, but later overwritten by bar renderer, making this block completely useless.